### PR TITLE
Fix: showcase link

### DIFF
--- a/korge/tutorials/index.md
+++ b/korge/tutorials/index.md
@@ -31,7 +31,7 @@ Our YouTube channel:
 We have a section in our blog with showcases showing games done with KorGE and with Source Code that
 can be used as a learning source:
 
-* <https://blog.korge.org/search/label/showcases> 
+* <https://blog.korge.org/tag/showcases/> 
 
 ## Samples
 


### PR DESCRIPTION
[https://blog.korge.org/search/label/showcases](https://blog.korge.org/search/label/showcases) is dead (404)
[https://blog.korge.org/tag/showcases/](https://blog.korge.org/tag/showcases/) = direct to showcases